### PR TITLE
feat(teardown): add automated teardown and multi-stack support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-keys/
+keys-*/
 echoer/
 aws/
-kind-irsa-config.yaml
+kind-irsa-*-config.yaml

--- a/README.md
+++ b/README.md
@@ -17,6 +17,30 @@ Each run automatically generates a unique UUID-based identifier, allowing multip
 ./full-setup.sh "my-dev-stack"
 ```
 
+## Configuration
+
+### AWS Region
+
+By default, all AWS resources (S3 buckets, IAM roles, OIDC providers) are created in `eu-west-1`. You can override this by setting the `AWS_DEFAULT_REGION` environment variable:
+
+```bash
+# Use default region (eu-west-1)
+./full-setup.sh
+
+# Use a different region
+AWS_DEFAULT_REGION=us-west-2 ./full-setup.sh
+
+# Combine with custom stack identifier
+AWS_DEFAULT_REGION=ap-southeast-1 ./full-setup.sh "my-dev-stack"
+```
+
+The region configuration affects:
+- S3 bucket locations for OIDC discovery and demo output
+- OIDC provider endpoint URLs
+- IAM resource creation
+- Kubernetes pod environment variables
+
+**Note:** Make sure to use the same region when running the teardown script, or specify the suffix of the stack you want to delete.
 
 ## Prerequisites
 
@@ -50,7 +74,7 @@ The teardown script will automatically detect deployed stacks and present an int
 This script will delete:
 - Kind cluster (`irsa-<suffix>`)
 - IAM role (`s3-echoer-<suffix>`)
-- OIDC provider (`s3.us-east-2.amazonaws.com/aws-irsa-oidc-discovery-<suffix>`)
+- OIDC provider (`s3.eu-west-1.amazonaws.com/aws-irsa-oidc-discovery-<suffix>`)
 - S3 buckets (`aws-irsa-oidc-discovery-<suffix>` and `output-bucket-s3-echoer-<suffix>`)
 - Local files specific to the stack (keys, configs, and generated manifests)
 - Empty `aws/` and `echoer/` directories (if no other stacks remain)

--- a/full-setup.sh
+++ b/full-setup.sh
@@ -139,7 +139,7 @@ echo "pod-identity-webhook is ready! Creating the echoer..."
 
 kubectl create sa s3-echoer
 kubectl annotate sa s3-echoer eks.amazonaws.com/role-arn=$S3_ROLE_ARN
-sed -e "s;SUFFIX;${suffix};g" templates/s3-echoer/s3-echoer-job.template.yaml >"$STACK_DIR/echoer/s3-echoer.yaml"
+sed -e "s;SUFFIX;${suffix};g" -e "s;AWS_REGION_PLACEHOLDER;${AWS_DEFAULT_REGION};g" templates/s3-echoer/s3-echoer-job.template.yaml >"$STACK_DIR/echoer/s3-echoer.yaml"
 kubectl create -f "$STACK_DIR/echoer/s3-echoer.yaml"
 
 echo "The Demo S3 bucket as below:"

--- a/full-setup.sh
+++ b/full-setup.sh
@@ -1,28 +1,32 @@
 # Pre-reqs: Have creds for an AWS account, have kubectl, aws-cli, jq, go and kind installed.
 
-# Unset pager for Linux users
-export AWS_PAGER=""
+# Source common functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
 
-# By changing the suffix, you can have multiple "versions" running at a time.
-# This is just a hacky way of easily running the script multiple times after each other with a fresh state.
-# Long-term, I should probably just have a clean-up script to call in between the runs.
-suffix="run-1"
+# Check for required binaries
+check_prerequisites kubectl aws jq go kind ssh-keygen openssl uuidgen
 
-# Note: For slower hardware, you may need to bump this higher
-# Otherwise, you may see cert-manager not starting up in time to sign the certificate needed for the webhook
-# I recommend watching along with k9s or manual kubectl commands to check that things start up in the right order.
-SLEEP_TIME="30"
+# Generate unique suffix for this stack
+# Optionally provide a seed phrase as first argument for reproducible/named stacks
+if [ -n "$1" ]; then
+    input_string="$1"
+    echo "Using provided stack identifier: $input_string"
+else
+    input_string=$(uuidgen)
+    echo "Generated new stack identifier: $input_string"
+fi
+suffix=$(generate_suffix "$input_string")
 
 # Generate keys for k8s configuration
-rm -rf keys
-mkdir -p keys
+rm -rf keys-$suffix
+mkdir -p keys-$suffix
 
 # make folder if it doesn't exist
 mkdir -p aws
 mkdir -p echoer
 
 # create S3 Bucket
-export AWS_DEFAULT_REGION="eu-west-1"
 export DISCOVERY_BUCKET="aws-irsa-oidc-discovery-$suffix"
 
 aws s3api create-bucket --bucket $DISCOVERY_BUCKET --create-bucket-configuration LocationConstraint=$AWS_DEFAULT_REGION
@@ -33,13 +37,13 @@ export ISSUER_HOSTPATH=$HOSTNAME/$DISCOVERY_BUCKET
 aws s3api put-public-access-block --bucket $DISCOVERY_BUCKET --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"
 
 # poor man's templating using sed. note the use of ; as a delimiter to avoid clashing with characters in the templating files.
-sed -e "s;DISCOVERY_BUCKET;${DISCOVERY_BUCKET};g" templates/aws/s3-readonly-policy.template.json >aws/s3-readonly-policy.json
-aws s3api put-bucket-policy --bucket $DISCOVERY_BUCKET --policy file://aws/s3-readonly-policy.json
+sed -e "s;DISCOVERY_BUCKET;${DISCOVERY_BUCKET};g" templates/aws/s3-readonly-policy.template.json >aws/s3-readonly-policy-$suffix.json
+aws s3api put-bucket-policy --bucket $DISCOVERY_BUCKET --policy file://aws/s3-readonly-policy-$suffix.json
 
 # Generate the keypair
-PRIV_KEY="keys/oidc-issuer.key"
-PUB_KEY="keys/oidc-issuer.key.pub"
-PKCS_KEY="keys/oidc-issuer.pub"
+PRIV_KEY="keys-$suffix/oidc-issuer.key"
+PUB_KEY="keys-$suffix/oidc-issuer.key.pub"
+PKCS_KEY="keys-$suffix/oidc-issuer.pub"
 
 # Generate a key pair
 ssh-keygen -t rsa -b 2048 -f $PRIV_KEY -m pem -N ""
@@ -48,12 +52,12 @@ ssh-keygen -t rsa -b 2048 -f $PRIV_KEY -m pem -N ""
 ssh-keygen -e -m PKCS8 -f $PUB_KEY >$PKCS_KEY
 
 # Use the PKCS_KEY to generate the JWKS key set for the JWKS endpoint of the Discovery Bucket
-go run -C keys-generator main.go -key "$PWD/$PKCS_KEY" | jq >aws/keys.json
+go run -C keys-generator main.go -key "$PWD/$PKCS_KEY" | jq >aws/keys-$suffix.json
 
 # Create and place discovery.json and keys.json in the discovery-bucket
-sed -e "s;ISSUER_HOSTPATH;${ISSUER_HOSTPATH};g" templates/aws/discovery.template.json >aws/discovery.json
-aws s3 cp ./aws/discovery.json s3://$DISCOVERY_BUCKET/.well-known/openid-configuration
-aws s3 cp ./aws/keys.json s3://$DISCOVERY_BUCKET/keys.json
+sed -e "s;ISSUER_HOSTPATH;${ISSUER_HOSTPATH};g" templates/aws/discovery.template.json >aws/discovery-$suffix.json
+aws s3 cp ./aws/discovery-$suffix.json s3://$DISCOVERY_BUCKET/.well-known/openid-configuration
+aws s3 cp ./aws/keys-$suffix.json s3://$DISCOVERY_BUCKET/keys.json
 
 echo "The service-account-issuer as below:"
 echo "https://$ISSUER_HOSTPATH"
@@ -67,17 +71,24 @@ aws iam create-open-id-connect-provider \
   --client-id-list sts.amazonaws.com
 
 # Setup k8s cluster:
-kind delete cluster --name irsa
+kind delete cluster --name irsa-$suffix
 
-sed -e "s;PWD;${PWD};g; s;DISCOVERY_BUCKET;${DISCOVERY_BUCKET};g" templates/kind/irsa-config.template.yaml >kind-irsa-config.yaml
-kind create cluster --config kind-irsa-config.yaml --name irsa
+sed -e "s;SUFFIX;${suffix};g; s;PWD;${PWD};g; s;DISCOVERY_BUCKET;${DISCOVERY_BUCKET};g" templates/kind/irsa-config.template.yaml >kind-irsa-$suffix-config.yaml
+kind create cluster --config kind-irsa-$suffix-config.yaml --name irsa-$suffix
 echo "Cluster has been set up. Setting up cert manager in a couple of seconds:"
 
 # Install cert manager instead of messing with certs manually:
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.6/cert-manager.yaml
-echo "cert manager has been applied. waiting a little bit again"
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
+echo "cert-manager has been applied. Waiting for deployments to be ready..."
 
-sleep $SLEEP_TIME
+kubectl wait --for=condition=available --timeout=300s \
+  deployment/cert-manager \
+  deployment/cert-manager-cainjector \
+  deployment/cert-manager-webhook \
+  -n cert-manager
+
+echo "cert-manager is ready!"
 
 # Setup k8s webhook auth stuff up. Heavily inspired by https://github.com/aws/amazon-eks-pod-identity-webhook/tree/master/deploy
 kubectl create -f pod-identity-webhook/auth.yaml
@@ -86,17 +97,17 @@ kubectl create -f pod-identity-webhook/cert.yaml
 kubectl create -f pod-identity-webhook/mutatingwebhook-ca-bundle.yaml
 
 # create iam role for s3 echoer job
-export ISSUER_URL="https://s3-eu-west-1.amazonaws.com/$DISCOVERY_BUCKET"
+export ISSUER_URL="https://s3-$AWS_DEFAULT_REGION.amazonaws.com/$DISCOVERY_BUCKET"
 export ISSUER_HOSTPATH=$(echo $ISSUER_URL | cut -f 3- -d'/')
 export ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 export PROVIDER_ARN="arn:aws:iam::$ACCOUNT_ID:oidc-provider/$ISSUER_HOSTPATH"
 export ROLE_NAME="s3-echoer-$suffix"
 
 echo "Creating Demo role: $ROLE_NAME"
-sed -e "s;PROVIDER_ARN;${PROVIDER_ARN};g; s;ISSUER_HOSTPATH;${ISSUER_HOSTPATH};g" templates/aws/irp-trust-policy.template.json >aws/irp-trust-policy.json
+sed -e "s;PROVIDER_ARN;${PROVIDER_ARN};g; s;ISSUER_HOSTPATH;${ISSUER_HOSTPATH};g" templates/aws/irp-trust-policy.template.json >aws/irp-trust-policy-$suffix.json
 aws iam create-role \
   --role-name $ROLE_NAME \
-  --assume-role-policy-document file://aws/irp-trust-policy.json
+  --assume-role-policy-document file://aws/irp-trust-policy-$suffix.json
 
 aws iam attach-role-policy \
   --role-name $ROLE_NAME \
@@ -116,14 +127,18 @@ aws s3api create-bucket \
 
 echo "Creating the pod-identity-webhook now. Hopefully all dependencies are up and running..."
 kubectl create -f pod-identity-webhook/deployment.yaml
-echo "Almost there. Let's just give the webhook some time to get started. It needs to be ready before the echoer is deployed"
-sleep $SLEEP_TIME
-echo "Creating the echoer. Cross your fingers!"
+echo "Waiting for pod-identity-webhook to be ready..."
+
+kubectl wait --for=condition=available --timeout=300s \
+  deployment/pod-identity-webhook \
+  -n default
+
+echo "pod-identity-webhook is ready! Creating the echoer..."
 
 kubectl create sa s3-echoer
 kubectl annotate sa s3-echoer eks.amazonaws.com/role-arn=$S3_ROLE_ARN
-sed -e "s;SUFFIX;${suffix};g" templates/s3-echoer/s3-echoer-job.template.yaml >echoer/s3-echoer.yaml
-kubectl create -f echoer/s3-echoer.yaml
+sed -e "s;SUFFIX;${suffix};g" templates/s3-echoer/s3-echoer-job.template.yaml >echoer/s3-echoer-$suffix.yaml
+kubectl create -f echoer/s3-echoer-$suffix.yaml
 
 echo "The Demo S3 bucket as below:"
 echo $TARGET_BUCKET

--- a/full-taredown.sh
+++ b/full-taredown.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Source common functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
+
+# Check for required binaries (fzf is optional)
+check_prerequisites aws kind
+
+# Determine which stack to tear down
+# Priority: 1) CLI argument, 2) Interactive fzf selection
+if [ -n "$1" ]; then
+    suffix="$1"
+    echo "Using suffix from command line: $suffix"
+elif suffix=$(select_stack_interactive); then
+    echo "Selected stack with suffix: $suffix"
+else
+    echo "No deployed stacks found or selection cancelled."
+    echo "Provide a suffix as an argument: ./full-taredown.sh <suffix>"
+    exit 1
+fi
+
+get_resource_names "$suffix"
+
+echo ""
+echo "Starting teardown with suffix: $suffix"
+echo "This will delete the following resources:"
+echo "  - Kind cluster: irsa-$suffix"
+echo "  - IAM Role: $ROLE_NAME"
+echo "  - OIDC Provider: $ISSUER_HOSTPATH"
+echo "  - S3 Bucket: $DISCOVERY_BUCKET"
+echo "  - S3 Bucket: $TARGET_BUCKET"
+echo "  - Local files for stack: $suffix"
+echo ""
+
+# Delete Kind cluster
+echo "Deleting Kind cluster..."
+kind delete cluster --name irsa-$suffix
+
+# Detach IAM policy from role
+echo "Detaching IAM policy from role..."
+aws iam detach-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess 2>/dev/null || echo "Policy already detached or role doesn't exist"
+
+# Delete IAM role
+echo "Deleting IAM role..."
+aws iam delete-role --role-name $ROLE_NAME 2>/dev/null || echo "Role already deleted or doesn't exist"
+
+# Delete OIDC provider
+export ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+export PROVIDER_ARN="arn:aws:iam::$ACCOUNT_ID:oidc-provider/$ISSUER_HOSTPATH"
+echo "Deleting OIDC provider..."
+aws iam delete-open-id-connect-provider --open-id-connect-provider-arn $PROVIDER_ARN 2>/dev/null || echo "OIDC provider already deleted or doesn't exist"
+
+# Delete target S3 bucket and contents
+echo "Deleting target bucket: $TARGET_BUCKET..."
+aws s3 rm s3://$TARGET_BUCKET --recursive 2>/dev/null || echo "Bucket already empty or doesn't exist"
+aws s3api delete-bucket --bucket $TARGET_BUCKET --region $AWS_DEFAULT_REGION 2>/dev/null || echo "Target bucket already deleted or doesn't exist"
+
+# Delete discovery S3 bucket and contents
+echo "Deleting discovery bucket: $DISCOVERY_BUCKET..."
+aws s3 rm s3://$DISCOVERY_BUCKET --recursive 2>/dev/null || echo "Bucket already empty or doesn't exist"
+aws s3api delete-bucket --bucket $DISCOVERY_BUCKET --region $AWS_DEFAULT_REGION 2>/dev/null || echo "Discovery bucket already deleted or doesn't exist"
+
+# Clean up local files specific to this stack
+echo "Cleaning up local files..."
+rm -rf keys-$suffix
+rm -f aws/keys-$suffix.json
+rm -f aws/discovery-$suffix.json
+rm -f aws/s3-readonly-policy-$suffix.json
+rm -f aws/irp-trust-policy-$suffix.json
+rm -f echoer/s3-echoer-$suffix.yaml
+rm -f kind-irsa-$suffix-config.yaml
+
+# Clean up directories if they are completely empty
+if [ -d "aws" ] && [ -z "$(ls -A aws)" ]; then
+    echo "Removing empty aws directory..."
+    rmdir aws
+fi
+
+if [ -d "echoer" ] && [ -z "$(ls -A echoer)" ]; then
+    echo "Removing empty echoer directory..."
+    rmdir echoer
+fi
+
+echo ""
+echo "Teardown complete!"

--- a/full-taredown.sh
+++ b/full-taredown.sh
@@ -22,6 +22,9 @@ fi
 
 get_resource_names "$suffix"
 
+# Set stack directory
+STACK_DIR="$HOME/.kind-irsa/$suffix"
+
 echo ""
 echo "Starting teardown with suffix: $suffix"
 echo "This will delete the following resources:"
@@ -30,7 +33,7 @@ echo "  - IAM Role: $ROLE_NAME"
 echo "  - OIDC Provider: $ISSUER_HOSTPATH"
 echo "  - S3 Bucket: $DISCOVERY_BUCKET"
 echo "  - S3 Bucket: $TARGET_BUCKET"
-echo "  - Local files for stack: $suffix"
+echo "  - Stack directory: $STACK_DIR"
 echo ""
 
 # Delete Kind cluster
@@ -63,25 +66,13 @@ echo "Deleting discovery bucket: $DISCOVERY_BUCKET..."
 aws s3 rm s3://$DISCOVERY_BUCKET --recursive 2>/dev/null || echo "Bucket already empty or doesn't exist"
 aws s3api delete-bucket --bucket $DISCOVERY_BUCKET --region $AWS_DEFAULT_REGION 2>/dev/null || echo "Discovery bucket already deleted or doesn't exist"
 
-# Clean up local files specific to this stack
-echo "Cleaning up local files..."
-rm -rf keys-$suffix
-rm -f aws/keys-$suffix.json
-rm -f aws/discovery-$suffix.json
-rm -f aws/s3-readonly-policy-$suffix.json
-rm -f aws/irp-trust-policy-$suffix.json
-rm -f echoer/s3-echoer-$suffix.yaml
-rm -f kind-irsa-$suffix-config.yaml
-
-# Clean up directories if they are completely empty
-if [ -d "aws" ] && [ -z "$(ls -A aws)" ]; then
-    echo "Removing empty aws directory..."
-    rmdir aws
-fi
-
-if [ -d "echoer" ] && [ -z "$(ls -A echoer)" ]; then
-    echo "Removing empty echoer directory..."
-    rmdir echoer
+# Clean up stack directory
+echo "Cleaning up stack directory..."
+if [ -d "$STACK_DIR" ]; then
+    rm -rf "$STACK_DIR"
+    echo "Removed: $STACK_DIR"
+else
+    echo "Stack directory not found: $STACK_DIR"
 fi
 
 echo ""

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export AWS_PAGER=""
-export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-2}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-eu-west-1}"
 
 # Check if required binaries are installed. Exits with error if any are missing.
 # Usage: check_prerequisites cmd1 cmd2 cmd3 ...

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+export AWS_PAGER=""
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-2}"
+
+# Check if required binaries are installed. Exits with error if any are missing.
+# Usage: check_prerequisites cmd1 cmd2 cmd3 ...
+check_prerequisites() {
+    local missing=()
+
+    for cmd in "$@"; do
+        if ! command -v "$cmd" &> /dev/null; then
+            missing+=("$cmd")
+        fi
+    done
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "Error: Missing required binaries:" >&2
+        for cmd in "${missing[@]}"; do
+            echo "  - $cmd" >&2
+        done
+        echo "" >&2
+        echo "Please install the missing prerequisites and try again." >&2
+        exit 1
+    fi
+}
+
+# Generate a numeric suffix from an input string using md5 hash.
+# This creates consistent, collision-resistant identifiers for AWS resources.
+# Usage: suffix=$(generate_suffix "input-string")
+generate_suffix() {
+    local input_string="$1"
+    local hash_hex=$(echo -n "$input_string" | md5sum | cut -f 1 -d " " | cut -c 1-4)
+    echo "$((0x$hash_hex))"
+}
+
+# List all deployed stacks by querying AWS S3 for OIDC discovery buckets.
+# Returns one suffix per line. Returns 1 if no stacks found.
+# Usage: stacks=$(list_deployed_stacks)
+list_deployed_stacks() {
+    local buckets=$(aws s3api list-buckets --query "Buckets[?starts_with(Name, 'aws-irsa-oidc-discovery-')].Name" --output text 2>/dev/null)
+
+    if [ -z "$buckets" ]; then
+        return 1
+    fi
+
+    for bucket in $buckets; do
+        local suffix="${bucket#aws-irsa-oidc-discovery-}"
+        echo "$suffix"
+    done
+}
+
+# Interactive stack selection using fzf.
+# Returns selected suffix or exits with error if no selection made.
+# If only one stack exists, returns it automatically.
+# Usage: suffix=$(select_stack_interactive)
+select_stack_interactive() {
+    local stacks=$(list_deployed_stacks)
+
+    if [ -z "$stacks" ]; then
+        echo "No deployed stacks found" >&2
+        return 1
+    fi
+
+    local stack_count=$(echo "$stacks" | wc -l)
+
+    if [ "$stack_count" -eq 1 ]; then
+        echo "$stacks"
+        return 0
+    fi
+
+    if ! command -v fzf &> /dev/null; then
+        echo "Multiple stacks found but fzf is not installed. Please specify suffix manually." >&2
+        return 1
+    fi
+
+    local selected=$(echo "$stacks" | fzf --prompt="Select stack to teardown: " --height=40%)
+
+    if [ -z "$selected" ]; then
+        echo "No stack selected" >&2
+        return 1
+    fi
+
+    echo "$selected"
+}
+
+# Generate AWS resource names based on suffix.
+# Exports environment variables for bucket names, role name, etc.
+# Usage: get_resource_names "12345"
+get_resource_names() {
+    local suffix="$1"
+    export DISCOVERY_BUCKET="aws-irsa-oidc-discovery-$suffix"
+    export HOSTNAME="s3-$AWS_DEFAULT_REGION.amazonaws.com"
+    export ISSUER_HOSTPATH="$HOSTNAME/$DISCOVERY_BUCKET"
+    export ROLE_NAME="s3-echoer-$suffix"
+    export TARGET_BUCKET="output-bucket-$ROLE_NAME"
+}

--- a/templates/kind/irsa-config.template.yaml
+++ b/templates/kind/irsa-config.template.yaml
@@ -8,7 +8,7 @@ kubeadmConfigPatches:
       service-account-signing-key-file: /etc/ca-certificates/irsa/oidc-issuer.key
       service-account-key-file: /etc/ca-certificates/irsa/oidc-issuer.pub
       api-audiences: sts.amazonaws.com
-      service-account-issuer: https://s3-us-east-2.amazonaws.com/DISCOVERY_BUCKET
+      service-account-issuer: https://HOSTNAME/DISCOVERY_BUCKET
 nodes:
 - role: control-plane
   extraMounts:

--- a/templates/kind/irsa-config.template.yaml
+++ b/templates/kind/irsa-config.template.yaml
@@ -8,11 +8,11 @@ kubeadmConfigPatches:
       service-account-signing-key-file: /etc/ca-certificates/irsa/oidc-issuer.key
       service-account-key-file: /etc/ca-certificates/irsa/oidc-issuer.pub
       api-audiences: sts.amazonaws.com
-      service-account-issuer: https://s3-eu-west-1.amazonaws.com/DISCOVERY_BUCKET
+      service-account-issuer: https://s3-us-east-2.amazonaws.com/DISCOVERY_BUCKET
 nodes:
 - role: control-plane
   extraMounts:
-  - hostPath: PWD/keys/ # <-- only use full paths here. local paths won't work
+  - hostPath: PWD/keys-SUFFIX/ # <-- only use full paths here. local paths won't work
     containerPath: /etc/ca-certificates/irsa/ # <-- Make sure to use a path under /ca-certificates as that is mounted in to the apiserver
     readOnly: true
 - role: worker

--- a/templates/kind/irsa-config.template.yaml
+++ b/templates/kind/irsa-config.template.yaml
@@ -12,7 +12,7 @@ kubeadmConfigPatches:
 nodes:
 - role: control-plane
   extraMounts:
-  - hostPath: PWD/keys-SUFFIX/ # <-- only use full paths here. local paths won't work
+  - hostPath: PWD/keys/ # <-- only use full paths here. local paths won't work
     containerPath: /etc/ca-certificates/irsa/ # <-- Make sure to use a path under /ca-certificates as that is mounted in to the apiserver
     readOnly: true
 - role: worker

--- a/templates/s3-echoer/s3-echoer-job.template.yaml
+++ b/templates/s3-echoer/s3-echoer-job.template.yaml
@@ -21,7 +21,7 @@ spec:
           done
         env:
         - name: AWS_DEFAULT_REGION
-          value: "eu-west-1"
+          value: "us-east-2"
         - name: ENABLE_IRP
           value: "true"
       restartPolicy: Never

--- a/templates/s3-echoer/s3-echoer-job.template.yaml
+++ b/templates/s3-echoer/s3-echoer-job.template.yaml
@@ -21,7 +21,7 @@ spec:
           done
         env:
         - name: AWS_DEFAULT_REGION
-          value: "us-east-2"
+          value: "AWS_REGION_PLACEHOLDER"
         - name: ENABLE_IRP
           value: "true"
       restartPolicy: Never


### PR DESCRIPTION
## Summary
  - Adds automated teardown script with interactive stack detection and fzf selection
  - Creates shared library (lib/common.sh) for common functions
  - Implements UUID-based unique stack identifiers with optional seed phrase
  - Replaces static sleep timers with kubectl wait for reliable dependency checking
  - Enables multiple concurrent stacks with suffix-specific isolated resources
  - Adds prerequisite checking on startup
  - Centralizes all stack files in user home directory (~/.kind-irsa/<suffix>)
  - Cleans up empty directories automatically after teardown
  - Updated cert-manager to v1.18.2

  ## Changes
  - **New**: `full-taredown.sh` - Automated teardown script with interactive selection
  - **New**: `lib/common.sh` - Shared functions for suffix generation, stack listing, resource naming
  - **Enhanced**: `full-setup.sh` - UUID generation, kubectl wait, prerequisite checks, centralized file storage
  - **Updated**: Templates to support centralized stack directory paths
  - **Updated**: Default AWS region changed to us-east-2
  - **Updated**: README with comprehensive teardown instructions

  ## Key Features

  ### Centralized Stack Storage
  - All stack-specific files now stored in `~/.kind-irsa/<suffix>/`
  - Keeps repository root clean and free of generated artifacts
  - Better isolation between multiple deployments
  - Simplified teardown by removing single directory tree
  - Directory structure: keys/, aws/, echoer/ all under stack directory

  ### Automated Teardown
  - Detects deployed stacks by querying AWS S3 for discovery buckets
  - Interactive fzf menu when multiple stacks exist
  - Can specify suffix directly: `./full-taredown.sh <suffix>`
  - Cleans up all AWS resources (IAM roles, OIDC providers, S3 buckets, Kind clusters)
  - Removes entire stack directory (~/.kind-irsa/<suffix>)
  - Automatically removes empty directories

  ### Multi-Stack Support
  - Each stack gets UUID-based unique identifier
  - Optional seed phrase: `./full-setup.sh "my-dev-stack"`
  - All files are isolated in suffix-specific directories
  - Kind clusters named `irsa-<suffix>` for isolation
  - Multiple stacks can run simultaneously

  ### Reliability Improvements
  - Prerequisite checking on startup (kubectl, aws, jq, go, kind, uuidgen, ssh-keygen, openssl)
  - kubectl wait for cert-manager (all 3 deployments) instead of static sleep
  - kubectl wait for pod-identity-webhook instead of static sleep
  - Consistent command-line interface between setup and teardown

  ## Test plan
  - [x] Run `./full-setup.sh` without arguments (generates UUID)
  - [x] Run `./full-setup.sh "my-dev-stack"` with seed phrase
  - [x] Deploy multiple stacks simultaneously with different seeds
  - [x] Run `./full-taredown.sh` with interactive fzf selection
  - [x] Run `./full-taredown.sh <suffix>` with specific suffix
  - [x] Verify all AWS resources are cleaned up (IAM, OIDC, S3)
  - [x] Verify stack directory ~/.kind-irsa/<suffix> is cleaned up
  - [x] Verify repository root remains clean (no keys/, aws/, echoer/ folders)
  - [x] Verify kubectl wait succeeds for cert-manager and webhook